### PR TITLE
add branchless binary search to the list of binary search algos

### DIFF
--- a/binary-search.c
+++ b/binary-search.c
@@ -70,6 +70,27 @@ int standard_binary_search(int *array, int array_size, int key)
 	return -1;
 }
 
+int branchless_binary_search(int *array, int array_size, int key)
+{
+    int lower, half, n, middle;
+
+    lower = 0;
+    n = array_size;
+    while (half = n/2) {
+	middle = lower + half;
+	++checks;
+	lower = ((array[middle]) <= key) ? middle : lower;
+	n -= half;
+    }
+
+    ++checks;
+    if (key == array[lower]) {
+	return lower;
+    }
+    return -1;
+}
+
+
 // slightly faster than the standard binary search
 
 int tailed_binary_search(int *array, int array_size, int key)
@@ -596,6 +617,7 @@ int main(int argc, char **argv)
 	run(boundless_quaternary_search);
 	run(inbound_quaternary_search);
 	run(boundless_interpolated_search);
+	run(branchless_binary_search);
 
 	for (cnt = 0, val = 0 ; cnt < max / 8 ; cnt++)
 	{
@@ -618,6 +640,7 @@ int main(int argc, char **argv)
 
 	// Begin
 	run(boundless_interpolated_search);
+	run(branchless_binary_search);
 
 	return 0;
 }


### PR DESCRIPTION
Hi,

Have added also branchless binary search (which is superior for random keys).
Please consider merging.


```
Even distribution with 100000 32 bit integers

|                           Name |      Items |       Hits |     Misses |     Checks |       Time |
|                     ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
|         standard_binary_search |     100000 |     197875 |    9802125 |  176901757 |   0.001559 |
|         standard_binary_search |     100000 |     197875 |    9802125 |  176901757 |   0.001560 |
|           tailed_binary_search |     100000 |     197875 |    9802125 |  176901757 |   0.001426 |
|        boundless_binary_search |     100000 |     197875 |    9802125 |  200406343 |   0.001069 |
|          inbound_binary_search |     100000 |     197875 |    9802125 |  180000000 |   0.001257 |
|    boundless_quaternary_search |     100000 |     197875 |    9802125 |  223608878 |   0.001038 |
|      inbound_quaternary_search |     100000 |     197875 |    9802125 |  208351360 |   0.001038 |
|  boundless_interpolated_search |     100000 |     197875 |    9802125 |  146245804 |   0.000717 |
|       branchless_binary_search |     100000 |     197875 |    9802125 |  180000000 |   0.000810 |


Uneven distribution with 100000 32 bit integers

|                           Name |      Items |       Hits |     Misses |     Checks |       Time |
|                     ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
|         standard_binary_search |     100000 |     224962 |    9775038 |  176895729 |   0.001528 |
|  boundless_interpolated_search |     100000 |     224962 |    9775038 |  277889644 |   0.001368 |
|       branchless_binary_search |     100000 |     224962 |    9775038 |  180000000 |   0.000783 |
```